### PR TITLE
간단한 개발환경 설정 업데이트

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,4 @@
+BasedOnStyle: Google
+DerivePointerAlignment: false
+PointerAlignment: Left
+ReferenceAlignment: Left

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,64 @@
+Checks:
+  google-*,
+  -google-objc-*,
+  readability-*,
+  performance-*,
+  bugprone-*,
+
+HeaderFilterRegex: '.*'
+
+CheckOptions:
+  - key: readability-identifier-naming.ClassCase
+    value: CamelCase
+  - key: readability-identifier-naming.ClassMemberCase
+    value: lower_case
+  - key: readability-identifier-naming.ConstexprVariableCase
+    value: CamelCase
+  - key: readability-identifier-naming.ConstexprVariablePrefix
+    value: k
+  - key: readability-identifier-naming.EnumCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.EnumConstantPrefix
+    value: k
+  - key: readability-identifier-naming.FunctionCase
+    value: CamelCase
+  - key: readability-identifier-naming.GlobalConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.GlobalConstantPrefix
+    value: k
+  - key: readability-identifier-naming.StaticConstantCase
+    value: CamelCase
+  - key: readability-identifier-naming.StaticConstantPrefix
+    value: k
+  - key: readability-identifier-naming.StaticVariableCase
+    value: lower_case
+  - key: readability-identifier-naming.MacroDefinitionCase
+    value: UPPER_CASE
+  - key: readability-identifier-naming.MacroDefinitionIgnoredRegexp
+    value: '^[A-Z]+(_[A-Z]+)*_$'
+  - key: readability-identifier-naming.PrivateMemberCase
+    value: lower_case
+  - key: readability-identifier-naming.ProtectedMemberCase
+    value: lower_case
+  - key: readability-identifier-naming.PublicMemberCase
+    value: lower_case
+  - key: readability-identifier-naming.PrivateMemberSuffix
+    value: _
+  - key: readability-identifier-naming.ProtectedMemberSuffix
+    value: _
+  - key: readability-identifier-naming.PublicMemberSuffix
+    value: ''
+  - key: readability-identifier-naming.NamespaceCase
+    value: lower_case
+  - key: readability-identifier-naming.ParameterCase
+    value: lower_case
+  - key: readability-identifier-naming.TypeAliasCase
+    value: CamelCase
+  - key: readability-identifier-naming.TypedefCase
+    value: CamelCase
+  - key: readability-identifier-naming.VariableCase
+    value: lower_case
+  - key: readability-identifier-naming.IgnoreMainLikeFunctions
+    value: 1

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,0 +1,7 @@
+-xc++
+-std=c++17
+-Iinclude
+-Wall
+-Wextra
+-Werror
+-Wpedantic


### PR DESCRIPTION
## 변경 사항
개발환경을 통일하기 위해 `.clang-format`, `.clang-tidy` 파일을 추가했습니다. 또한 이 프로젝트에서 `CMakeLists.txt`를 작성하기 전에, 정적분석 기능을 활용하기 위해 임시적으로 사용할 `compile_flags.txt` 파일을 추가했습니다.

### 변경 유형
- ✨ 새로운 기능

## 변경 내용
- `.clang-format`:
Google 스타일을 기반으로 하여, 포인터와 레퍼런스 타입의 포맷팅을 Google guide에 맞추기 위해 강제적으로 포맷팅하는 옵션을 추가했습니다.
[Pointer_and_Reference_Expressions](https://google.github.io/styleguide/cppguide.html#Pointer_and_Reference_Expressions)

- `.clang-tidy`:
clang-tidy의 체크 옵션 중, google(Object C는 제외), readability, performance, bugprone 기능을 활성화했습니다. 또한 identifier 네이밍 컨벤션을 맞추기 위해 아래 파일의 내용을 넣었습니다.
[clang-tidy-readability-identifier-naming-google.yml](https://gist.github.com/airglow923/1fa3bda42f2b193920d7f46ee8345e04)

-`compile_flags.txt`
all, extra, pedantic 경고 옵션을 켜고, 경고를 컴파일 에러로 발생하게 설정했습니다. `include` 디렉토리는 `include`로 가정했습니다.

## 테스트
<img width="737" height="373" alt="image" src="https://github.com/user-attachments/assets/8ef24374-9e07-4dda-87e1-7e3881bde949" />

## 참고사항
`compiles_flags.txt`는 `CMakeLists.txt`를 추가한 다음엔 지워도 상관 없습니다.
